### PR TITLE
Add CSVs and markdown files for all known teams

### DIFF
--- a/teams/arm-arch.csv
+++ b/teams/arm-arch.csv
@@ -1,0 +1,4 @@
+github_username,email,name
+hmaarrfk,mark.harfouche@gmail.com,Mark Harfouche
+mariusvniekerk,marius.v.niekerk@gmail.com,Marius van Niekerk
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/arm-arch.md
+++ b/teams/arm-arch.md
@@ -1,0 +1,21 @@
+## ARM Sub-Team
+
+### Role
+
+Develop and manage ARM architecture support for conda-forge.
+
+### Charter
+
+Dynamic
+
+### Responsibility
+
+This sub-team is broadly responsible for enabling the ARM architecture.
+This includes updates and enabling features to:
+
+- staged-recipes
+- CI interfaces
+- conda-smithy
+- Docker containers
+
+And other parts of the conda-forge ecosystem.

--- a/teams/bioconda-recipes.csv
+++ b/teams/bioconda-recipes.csv
@@ -1,0 +1,7 @@
+github_username,email,name
+bgruening,,Björn Grüning
+daler,,Ryan Dale
+druvus,,Andreas Sjödin
+johanneskoester,,Johannes Koester
+mbargull,marcel.bargull@udo.edu,Marcel Bargull
+mfansler,,Mervin Fansler

--- a/teams/bioconda-recipes.md
+++ b/teams/bioconda-recipes.md
@@ -1,0 +1,1 @@
+## Bioconda-recipes Sub-Team

--- a/teams/bot.csv
+++ b/teams/bot.csv
@@ -1,0 +1,7 @@
+github_username,email,name
+beckermr,becker.mr@gmail.com,Matthew R. Becker
+chrisburr,christopher.burr@cern.ch,Chris Burr
+isuruf,isuruf@gmail.com,Isuru Fernando
+mariusvniekerk,marius.v.niekerk@gmail.com,Marius van Niekerk
+ocefpaf,ocefpaf@gmail.com,Filipe Pires Alvarenga Fernandes
+soapy1,scastellarin@quansight.com,Sophia Castellarin

--- a/teams/bot.md
+++ b/teams/bot.md
@@ -1,0 +1,37 @@
+## Bot Sub-Team
+
+### Role
+
+Develop and manage the conda-forge migration bot and all related tooling.
+Also manages and deploys migrations themselves.
+
+### Charter
+
+Dynamic
+
+### Responsibility
+
+The migration and autotick bot is now a central part of the conda-forge ecosystem.
+This subteam has the right and responsibility to manage and develop the general
+operation of the bot.
+This includes building new migrators, fixing migration related bugs, and tooling.
+Example migrations that can happen include:
+
+- Compiler bumps
+- Python version bump
+- R version bump
+- Build number bumps of the ecosystem when a pinned package version updates and
+  there is a binary incompatibility which necessitates downstream rebuilds.
+- Automatically version bumping of feedstocks when the package releases a new version.
+
+For large scale (affecting >20% of packages) this sub-team will inform and
+discuss with the core team about the upcoming migration prior to starting the
+migration.
+
+Packages and tools that fall under the purview of the bot subteam include:
+
+- cf-scripts
+- libcflib
+- libcfgraph
+- cf-graph
+- circle-worker

--- a/teams/dei.csv
+++ b/teams/dei.csv
@@ -1,0 +1,3 @@
+github_username,email,name
+marcelotrevisani,marceloduartetrevisani@gmail.com,Marcelo Duarte Trevisani
+ocefpaf,ocefpaf@gmail.com,Filipe Pires Alvarenga Fernandes

--- a/teams/dei.md
+++ b/teams/dei.md
@@ -1,0 +1,23 @@
+## Diversity and Inclusion Sub-Team
+
+### Role
+
+Develop conda-forge as a diverse community and advocate for
+actions impacting underrepresented groups in conda-forge.
+
+### Charter
+
+Dynamic
+
+### Responsibility
+
+One of the core strengths of conda-forge is the diversity of ecosystems it supports.
+Likewise, fostering and advancing a diverse community of users, maintainers, and infrastructure contributors
+is an important part of creating and maintaining a vibrant project.
+The mandate of this subteam is to support and increase the diversity of the conda-forge
+community at all levels.
+As such this group can, but is not limited to:
+
+- provide a place for issues impacting diversity to be heard
+- advocate for underrepresented groups and bring their issues to the attention of core
+- run programs to maintain and grow the community's diversity and inclusiveness

--- a/teams/docs.csv
+++ b/teams/docs.csv
@@ -1,0 +1,2 @@
+github_username,email,name
+jaimergp,jrodriguez@quansight.com,Jaime Rodríguez-Guerra

--- a/teams/docs.md
+++ b/teams/docs.md
@@ -1,0 +1,28 @@
+## Docs Sub-Team
+
+### Role
+
+Maintain and improve the documentation. Review, organize and help with documentation related issues.
+
+### Charter
+
+Dynamic
+
+### Responsibility
+
+Good documentation is an important cornerstone of a successful community project.
+Accurate, well organized and comprehensive documentation not only benefits users, but also frees
+the core team by decreasing support requests.
+
+The documentation team is responsible for:
+
+- Keeping the documentation accurate and up-to-date.
+- Help expanding the documentation by identifying new topics of common interest.
+- Improving the documentation by reorganizing and clarifying its contents.
+- Giving feedback on community contributions to the documentation.
+
+As such following task are performed by the documentation team:
+
+- Reviewing and organizing documentation related issues and PRs in `conda-forge.github.io`.
+- Proposing improvements and new content by opening issues and pull requests.
+- Engaging with the community to ensure the effectiveness of the documentation.

--- a/teams/finances.csv
+++ b/teams/finances.csv
@@ -1,0 +1,3 @@
+github_username,email,name
+ericdill,ericdill@pm.me,Eric Dill
+ocefpaf,ocefpaf@gmail.com,Filipe Pires Alvarenga Fernandes

--- a/teams/finances.md
+++ b/teams/finances.md
@@ -1,0 +1,28 @@
+## Finances Sub-Team
+
+### Role
+
+The purpose of the finance sub-team is to provide a point of contact
+for financial and budgetary issues. This includes keeping core aware
+of the current conda-forge balance via `core` meetings and facilitating
+dispersal of funds.
+
+### Charter
+
+Static
+
+### Responsibility
+
+The core responsibilities of this team are as follows:
+
+- Keep core aware of budgetary and financial matters pertaining to conda-forge.
+- Facilitate dispersal of funds.
+- Give core updates via the standing budget item at core meetings.
+- Work closely with the NumFOCUS point of contact to ensure smooth financial operations.
+
+This team will operate via the following rules:
+
+- Only members of `core` can be on this sub-team.
+- This sub-team will report its activity to core at all attended `core` meetings.
+- This sub-team will not approve or deny access to funds unless instructed to
+  via the method specified by the conda-forge governance document.

--- a/teams/help-c-cpp.csv
+++ b/teams/help-c-cpp.csv
@@ -1,0 +1,6 @@
+github_username,email,name
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+marcelotrevisani,marceloduartetrevisani@gmail.com,Marcelo Duarte Trevisani
+saraedum,,Julian Rüth
+SylvainCorlay,sylvain.corlay@gmail.com,Sylvain Corlay
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/help-c-cpp.md
+++ b/teams/help-c-cpp.md
@@ -1,0 +1,3 @@
+## help-c-cpp Sub-team
+
+Reviewers and troubleshooters of C and C++ feedstocks

--- a/teams/help-cdts.csv
+++ b/teams/help-cdts.csv
@@ -1,0 +1,1 @@
+github_username,email,name

--- a/teams/help-cdts.md
+++ b/teams/help-cdts.md
@@ -1,0 +1,3 @@
+## help-cdts Sub-team
+
+Reviewers and troubleshooters of the CDTs feedstock

--- a/teams/help-go.csv
+++ b/teams/help-go.csv
@@ -1,0 +1,4 @@
+github_username,email,name
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+sodre,psodre@gmail.com,Patrick Sodré
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/help-go.md
+++ b/teams/help-go.md
@@ -1,0 +1,3 @@
+## help-go Sub-team
+
+Reviewers and troubleshooters of Go feedstocks

--- a/teams/help-java.csv
+++ b/teams/help-java.csv
@@ -1,0 +1,4 @@
+github_username,email,name
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+mariusvniekerk,marius.v.niekerk@gmail.com,Marius van Niekerk
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/help-java.md
+++ b/teams/help-java.md
@@ -1,0 +1,3 @@
+## help-java Sub-team
+
+Reviewers and troubleshooters of Java feedstocks

--- a/teams/help-nodejs.csv
+++ b/teams/help-nodejs.csv
@@ -1,0 +1,3 @@
+github_username,email,name
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/help-nodejs.md
+++ b/teams/help-nodejs.md
@@ -1,0 +1,3 @@
+## help-nodejs Sub-team
+
+Reviewers and troubleshooters of NodeJS feedstocks

--- a/teams/help-perl.csv
+++ b/teams/help-perl.csv
@@ -1,0 +1,2 @@
+github_username,email,name
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun

--- a/teams/help-perl.md
+++ b/teams/help-perl.md
@@ -1,0 +1,3 @@
+## help-perl Sub-team
+
+Reviewers and troubleshooters of Perl feedstocks

--- a/teams/help-python-c.csv
+++ b/teams/help-python-c.csv
@@ -1,0 +1,7 @@
+github_username,email,name
+chrisburr,christopher.burr@cern.ch,Chris Burr
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+mariusvniekerk,marius.v.niekerk@gmail.com,Marius van Niekerk
+mwcraig,mattwcraig@gmail.com,Matt Craig
+synapticarbors,joshua.adelman@gmail.com,Joshua Adelman
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/help-python-c.md
+++ b/teams/help-python-c.md
@@ -1,0 +1,3 @@
+## help-python-c Sub-team
+
+Reviewers and troubleshooters of Python and C feedstocks

--- a/teams/help-python.csv
+++ b/teams/help-python.csv
@@ -1,0 +1,13 @@
+github_username,email,name
+BastianZim,,Bastian Zimmermann
+beenje,,Benjamin Bertrand
+chrisburr,christopher.burr@cern.ch,Chris Burr
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+dopplershift,rmay@ucar.edu,Ryan May
+isuruf,isuruf@gmail.com,Isuru Fernando
+marcelotrevisani,marceloduartetrevisani@gmail.com,Marcelo Duarte Trevisani
+mariusvniekerk,marius.v.niekerk@gmail.com,Marius van Niekerk
+mwcraig,mattwcraig@gmail.com,Matt Craig
+ocefpaf,ocefpaf@gmail.com,Filipe Pires Alvarenga Fernandes
+saraedum,,Julian Rüth
+synapticarbors,joshua.adelman@gmail.com,Joshua Adelman

--- a/teams/help-python.md
+++ b/teams/help-python.md
@@ -1,0 +1,3 @@
+## help-python Sub-team
+
+Reviewers and troubleshooters of pure Python feedstocks

--- a/teams/help-r.csv
+++ b/teams/help-r.csv
@@ -1,0 +1,8 @@
+github_username,email,name
+bgruening,,Björn Grüning
+cbrueffer,,Christian Brueffer
+daler,,Ryan Dale
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+dbast,,Daniel Bast
+johanneskoester,,Johannes Köster
+mfansler,,Mervin Fansler

--- a/teams/help-r.md
+++ b/teams/help-r.md
@@ -1,0 +1,3 @@
+## help-r Sub-team
+
+Reviewers and troubleshooters of R feedstocks

--- a/teams/help-rust.csv
+++ b/teams/help-rust.csv
@@ -1,0 +1,3 @@
+github_username,email,name
+danielnachun,daniel.nachun@gmail.com,Daniel Nachun
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/help-rust.md
+++ b/teams/help-rust.md
@@ -1,0 +1,3 @@
+## help-rust Sub-team
+
+Reviewers and troubleshooters of Rust feedstocks

--- a/teams/miniforge.csv
+++ b/teams/miniforge.csv
@@ -1,0 +1,4 @@
+github_username,email,name
+hmaarrfk,mark.harfouche@gmail.com,Mark Harfouche
+isuruf,isuruf@gmail.com,Isuru Fernando
+xhochy,mail@uwekorn.com,Uwe L. Korn

--- a/teams/miniforge.md
+++ b/teams/miniforge.md
@@ -1,0 +1,14 @@
+## Miniforge Sub-Team
+
+### Role
+
+Develop and manage miniforge installers for conda-forge
+
+### Charter
+
+Dynamic
+
+### Responsibility
+
+This sub-team is broadly responsible for developing, maintaining and releasing
+miniforge installers.

--- a/teams/security.csv
+++ b/teams/security.csv
@@ -1,0 +1,3 @@
+github_username,email,name
+beckermr,becker.mr@gmail.com,Matthew R. Becker
+jaimergp,jrodriguez@quansight.com,Jaime Rodríguez-Guerra

--- a/teams/security.md
+++ b/teams/security.md
@@ -1,0 +1,34 @@
+## Security and Systems Sub-Team
+
+### Role
+
+The purpose of the security and systems sub-team is to secure and maintain appropriate access
+to the credentials and services/systems used by conda-forge. This infrastructure
+includes all bot accounts, all service provider accounts, and all keys, API or otherwise,
+used for various tasks. This team is also charged with provisioning new members of `core`
+with access to the organization.
+
+### Charter
+
+Static
+
+### Responsibility
+
+The core responsibilities of this team are as follows:
+
+- Maintain secure access to the credentials to all bot accounts.
+- Maintain secure access to all keys, API or otherwise, used by conda-forge.
+- Maintain secure access to all service provider accounts owned by conda-forge.
+- Maintain the infrastructure for `CFEP-13`.
+- Maintain automated ways to recover and reprovision conda-forge systems.
+- Perform ongoing security maintenance tasks.
+- Provision new members of core with access to all conda-forge systems, credentials
+  and keys.
+
+This team will operate via the following rules:
+
+- Only members of `core` can be on this sub-team.
+- This sub-team will report its activity to core at all `core` meetings.
+- This sub-team will consult with core at `core` meetings regarding all planned activity.
+- This sub-team will not limit the access by `core` members to any conda-forge resources
+  including but not limited to its systems, credentials, keys, or service accounts.

--- a/teams/staged-recipes.csv
+++ b/teams/staged-recipes.csv
@@ -1,0 +1,2 @@
+github_username,email,name
+sodre,psodre@gmail.com,Patrick Sodré

--- a/teams/staged-recipes.md
+++ b/teams/staged-recipes.md
@@ -1,0 +1,23 @@
+## Staging Sub-Team
+
+### Role
+
+Review and merge feedstock candidates in the staged-recipes repository. Help users to create
+conda-forge compatible recipes.
+
+### Charter
+
+Dynamic
+
+### Responsibility
+
+Introducing a recipe for most users is the first step of becoming involved with the development of conda-forge.
+Especially for new maintainers it is crucial to be able to ask questions and receive helpful and constructive feedback.
+
+The staging team is responsible for:
+
+- Reviewing and merging pull requests in `conda-forge/staged-recipes`.
+- Answering questions and giving feedback regarding conda-forge requirements.
+- Identifying common misconceptions and problems due to unclear documentation.
+- Help the documentation team maintain clear documentation that simplifies contributing packages.
+- Assist core in supporting feedstock maintainers when questions/issues arise during recipe maintenance.


### PR DESCRIPTION
I took the content from https://conda-forge.org/community/subteams/, split it in different files, and then checked our Github teams for some others that we don't have. I might have missed some because I realized we have a flat namespace for all the organizational teams and the auto-generated feedstock teams... might need to do something about it.
