### PR TITLE
clarify access rights of emeritus members

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Here are defined the primary teams participating in conda-forge activities.
   at least follow the same contacting methods stated for Time-out Quorum Rules.
   Any core member can also request to become emeritus if they wish to do so
   (e.g. taking a sabbatical or long vacation). Emeritus core members can still
-  vote and move back to active core anytime, but do not remain "owners" of the
-  conda-forge github organization. Emeritus votes are used to count
+  vote and move back to active core anytime, but will not retain privileged
+  access to any conda-forge service. Emeritus votes are used to count
   towards quorum but the quorum size is computed from the size of the active
   core group. The `core.csv` and `emeritus.csv` lists must be updated when
   a change in the status of a member occurs.
@@ -360,6 +360,6 @@ This document was written by Anthony Scopatz.
 In April 2025, two new clauses were added regarding core and core-emeritus
 membership.
 
-In September 2025, a new clauses was added to clarify access rights of emeritus members.
+In September 2025, a new clause was added to clarify access rights of emeritus members.
 
 This document is released under the CC-BY 4.0 license.


### PR DESCRIPTION
One of the things that we overlooked in https://github.com/conda-forge/conda-forge.github.io/pull/2501 was to clarify that emeritus members do not retain the "keys to the kingdom" while being emeritus.

Removing the access of emeritus members is self-evident for two reasons:
* Even the most basic security posture requires to not let highly privileged accounts just lying around. Emeritus [means](https://www.thefreedictionary.com/emeritus) "Retired but retaining an honorary title". You'll also have to give back the keys to the office building when you retire from a non-digital job, and the situation is no different here.
* We explicitly place absolutely no hurdles on emeritus members wanting to rejoin core; raising a one-line PR to this repo cannot be considered an undue burden for people wanting to rejoin.

Despite unanimous support for https://github.com/conda-forge/conda-forge.github.io/pull/2501, I assume this PR will need a full vote nevertheless. 🙃 